### PR TITLE
Merge missing sed flag fix

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,7 +16,7 @@ if [ "$(uname)" == "Darwin" ]; then
 
 else
 
-    sed 's/-O2/-O2 -fPIC/g' config.status
+    sed -i 's/-O2/-O2 -fPIC/g' config.status
 
 fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a fork of the feedstock to propose changes
* [X] Bumped the build number (if the version is unchanged)
* [X] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fix issue with missing flag in build.sh sed command (linux case)
<!--
Please add any other relevant info below:
-->
