### PR TITLE
include bundled dependency headers under healpix_cxx directory

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,13 +11,9 @@ autoreconf --install
 # Add enable-pic flag so libsharp.a can be linked into libhealpix_cxx later
 ./configure --prefix=$PREFIX --disable-silent-rules --disable-dependency-tracking --disable-static
 
-export EXTERNAL_CFITSIO=yes  
-export CFITSIO_EXT_LIB=${PREFIX}/lib  
-export CFITSIO_EXT_INC=${PREFIX}/include  
-
 make install -j ${CPU_COUNT}
 
-find . -name '*.h' -exec cp --parents {} ${PREFIX}/include/healpix_cxx/ \;
+find .. -name '*.h' -exec cp {} ${PREFIX}/include/healpix_cxx/ \;
 
 # delete all libsharp files as they are not needed
 rm -f $PREFIX/lib/libsharp.a

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
 build:
   run_exports:
     - {{ pin_subpackage("healpix_cxx", max_pin="x.x") }}
-  number: 1005
+  number: 1006
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Restores the previously bundled headers for cxxsupport and included dependencies libsharp, fftpack. Should not conflict with other conda-forge package headers as they are encapsulated under the include/healpix_cxx directory